### PR TITLE
Update cookbook.rst k-mer minimizer example

### DIFF
--- a/docs/sphinx/cookbook.rst
+++ b/docs/sphinx/cookbook.rst
@@ -84,7 +84,7 @@ k-mer minimizer
             if kmer < kmer_min: kmer_min = kmer
         return kmer_min
 
-    print minimizer[Kmer[10]](s)
+    print minimizer[Kmer[10]](s'ACGTACGTACGT')
 
 Count bases
 -----------


### PR DESCRIPTION
If working through these examples sequentially, the assertion in the k-mer minimizer example fails since the most recent prior def of s is 'GGATC'.