### PR TITLE
gzwrite expects an unsigned int for its length parameter.

### DIFF
--- a/stdlib/core/file.seq
+++ b/stdlib/core/file.seq
@@ -151,7 +151,7 @@ class gzFile:
 
     def write(self: gzFile, s: str):
         self._ensure_open()
-        _C.gzwrite(self.fp, s.ptr, i32(len(s)))
+        _C.gzwrite(self.fp, s.ptr, u32(len(s)))
         _gz_errcheck(self.fp)
 
     def write_gen[T](self: gzFile, g: generator[T]):


### PR DESCRIPTION
gzwrite expects an unsigned int for its length parameter.