### PR TITLE
Fix paired property of SAMRecord.

### DIFF
--- a/stdlib/bio/bam.seq
+++ b/stdlib/bio/bam.seq
@@ -387,7 +387,7 @@ class SAMRecord:
         '''
         Whether this record is paired
         '''
-        return self._htsr.flag & BAM_FREVERSE != 0
+        return self._htsr.flag & BAM_FPAIRED != 0
 
     @property
     def proper_pair(self: SAMRecord):


### PR DESCRIPTION
Fix paired property of SAMRecord as it was checking if the read was
reversed instead of paired.